### PR TITLE
fallback to screenshots from external db when no thumbnail available

### DIFF
--- a/react/actions/actionCreators.js
+++ b/react/actions/actionCreators.js
@@ -19,6 +19,10 @@ function injectScreenshots(response, callback){
   if(gistsWithoutThumbIds.length > 0){
     d3.json("http://69.164.216.89:8080")
       .post(JSON.stringify({"gists":gistsWithoutThumbIds}), function(error, data) {
+        if(error){
+          console.error('Invalid response from screenshot API.', 'Error: ' + JSON.stringify(error), 'Reponse: ' + JSON.stringify(data));
+          return callback.call(this, response);
+        }
         gistsWithoutThumb.forEach(function(d){ return d._source.thumbBase64 = data[d._id]; });
         callback.call(this, response);
       });
@@ -32,7 +36,11 @@ function injectScreenshots(response, callback){
 function getSearch(query) {
   return dispatch => {
     dispatch(requestSearch(query));
-    d3.json('/api/search?' + qs.stringify(query), function(err, response) {
+    d3.json('http://blockbuilder.org/api/search?' + qs.stringify(query), function(err, response) {
+        if(err || !response.hits || !response.hits.hits){
+          console.error('Invalid response from search API.', 'Error: ' + err, 'Reponse: ' + JSON.stringify(response));
+          return dispatch(receiveSearch(response));
+        }
       injectScreenshots(response, function(responseWithScreenshots){
         dispatch(receiveSearch(responseWithScreenshots));
       });
@@ -45,7 +53,7 @@ function getPage(query, from) {
   var q = {...query, from: from}
   return dispatch => {
     dispatch(requestPage(q));
-    d3.json('/api/search?' + qs.stringify(q), function(err, response) {
+    d3.json('http://blockbuilder.org/api/search?' + qs.stringify(q), function(err, response) {
         injectScreenshots(response, function(responseWithScreenshots){
           dispatch(receivePage(responseWithScreenshots));
         });
@@ -57,7 +65,7 @@ function getPage(query, from) {
 function getAggregateD3API() {
   return dispatch => {
     dispatch(requestAggregateD3API());
-    d3.json('/api/aggregateD3API', function(err, response) {
+    d3.json('http://blockbuilder.org/api/aggregateD3API', function(err, response) {
         dispatch(receiveAggregateD3API(response))
       })
   };

--- a/react/components/results.js
+++ b/react/components/results.js
@@ -20,6 +20,9 @@ const ResultsComponent = React.createClass({
       if(block.thumb) {
         style.backgroundImage = "url(https://gist.githubusercontent.com/" + block.userId + "/" + d._id + "/raw/" + block.thumb + "/thumbnail.png)"
       }
+      else if(block.thumbBase64){
+        style.backgroundImage = "url(data:image/png;base64," + block.thumbBase64 + ")"
+      }
       return (
         <a key={"block-" + d._id} className="block-link" href={"/" + block.userId + "/" + d._id} style={style} target="_blank">
           <div className="block-description">{block.description}</div>

--- a/react/reducer.js
+++ b/react/reducer.js
@@ -28,10 +28,10 @@ function rootReduce(state = initialState, action) {
 		case actions.RECEIVE_SEARCH:
       //console.log("ACTION RECEIVE SEARCH", action)
 			return {
-				...state,
+		...state,
         loading: false,
-        results: action.data.hits.hits, // TODO: null check this
-        totalResults: action.data.hits.total,
+        results: (action.data.hits) ? action.data.hits.hits : [],
+        totalResults: (action.data.hits) ? action.data.hits.total : 0,
         //aggregations: action.data.aggregations
 			}
     case actions.REQUEST_PAGE:


### PR DESCRIPTION
[Christian Jauvin](https://github.com/cjauvin) scraped all the 11K bl.ocks to take a screenshot of each of them. More than 10K worked. So we can show them when no thumbnail is available on the gallery.