### PR TITLE
[feature] Limit search results to blocks with README.md files

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux'
-import React, { Component } from 'react'
+import React from 'react'
 import { bindActionCreators } from 'redux'
-import { createSelector } from 'reselect'
 import ReactTooltip from 'react-tooltip'
 import ActionCreators from '../actions/actionCreators'
 import updateQueryString from '../util/update-query-string.js'
 import removeLocationHash from '../util/remove-location-hash.js'
+
+import { README_FILENAME, THUMB_FILENAME } from '../constants';
 
 import Header from './header'
 import Results from './results'
@@ -60,13 +61,24 @@ class App extends React.Component {
           // to check if string value is boolean true
           // eslint-disable-next-line eqeqeq
           if (value === 'true') {
-            query.filenames.push('thumbnail.png')
+            query.filenames.push(THUMB_FILENAME)
           } else {
             // look for 'thumbnail.png' and remove it if we find it
-            const thumbIndex = query.filenames.indexOf('thumbnail.png')
+            const thumbIndex = query.filenames.indexOf(THUMB_FILENAME)
             if (thumbIndex > -1) {
               query.filenames.splice(thumbIndex, 1)
             }
+          }
+          break
+        case 'hasReadme':
+          if (!Array.isArray(query.filenames)) query.filenames = []
+          // intentionally use double equals type coercion
+          // to check if string value is boolean true
+          // eslint-disable-next-line eqeqeq
+          if (value === 'true') {
+            query.filenames.push(README_FILENAME)
+          } else {
+            query.filenames = query.filenames.filter(filename => filename !== README_FILENAME)
           }
           break
         default:

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -57,9 +57,6 @@ class App extends React.Component {
           break
         case 'thumb':
           if (!Array.isArray(query.filenames)) query.filenames = []
-          // intentionally use double equals type coercion
-          // to check if string value is boolean true
-          // eslint-disable-next-line eqeqeq
           if (value === 'true') {
             query.filenames.push(THUMB_FILENAME)
           } else {
@@ -72,9 +69,6 @@ class App extends React.Component {
           break
         case 'hasReadme':
           if (!Array.isArray(query.filenames)) query.filenames = []
-          // intentionally use double equals type coercion
-          // to check if string value is boolean true
-          // eslint-disable-next-line eqeqeq
           if (value === 'true') {
             query.filenames.push(README_FILENAME)
           } else {

--- a/src/components/results.js
+++ b/src/components/results.js
@@ -70,18 +70,20 @@ class ResultsComponent extends React.Component {
     let results = this.props.results
 
     // filter results by member filenames
-    // if we are querying for only blocks with thumbnail images
     const hasFiles = typeof query.filenames !== 'undefined';
-    if (hasFiles && query.filenames.indexOf(THUMB_FILENAME) > -1) {
-      results = this.props.results.filter(
-        d => typeof d._source.thumb !== 'undefined'
-      )
-    }
-    // if we are querying for only blocks with README.md
-    if (hasFiles && query.filenames.includes(README_FILENAME)) {
-      results = this.props.results.filter(
-        d => d._source.filenames.includes(README_FILENAME)
-      )
+    if (hasFiles) {
+      // if we are querying for only blocks with thumbnail images
+      if (query.filenames.includes(THUMB_FILENAME)) {
+        results = results.filter(
+          d => typeof d._source.thumb !== 'undefined'
+        )
+      }
+      // if we are querying for only blocks with README.md
+      if (query.filenames.includes(README_FILENAME)) {
+        results = results.filter(
+          d => d._source.filenames.includes(README_FILENAME)
+        )
+      }
     }
 
     const totalResults = this.props.totalResults || 0

--- a/src/components/results.js
+++ b/src/components/results.js
@@ -1,8 +1,8 @@
 import Mousetrap from 'mousetrap'
-import React, { Component } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import { IconLoader } from './icons'
-import { graphSearchIPAddress } from '../constants'
+import { graphSearchIPAddress, README_FILENAME, THUMB_FILENAME } from '../constants'
 
 import './results.scss'
 
@@ -69,15 +69,21 @@ class ResultsComponent extends React.Component {
     // console.log('query', query)
     let results = this.props.results
 
+    // filter results by member filenames
     // if we are querying for only blocks with thumbnail images
-    if (
-      typeof query.filenames !== 'undefined' &&
-      query.filenames.indexOf('thumbnail.png') > -1
-    ) {
+    const hasFiles = typeof query.filenames !== 'undefined';
+    if (hasFiles && query.filenames.indexOf(THUMB_FILENAME) > -1) {
       results = this.props.results.filter(
         d => typeof d._source.thumb !== 'undefined'
       )
     }
+    // if we are querying for only blocks with README.md
+    if (hasFiles && query.filenames.includes(README_FILENAME)) {
+      results = this.props.results.filter(
+        d => d._source.filenames.includes(README_FILENAME)
+      )
+    }
+
     const totalResults = this.props.totalResults || 0
     const screenshots = this.props.screenshots || []
     // var aggregations = this.props.aggregations;

--- a/src/components/searchbar.js
+++ b/src/components/searchbar.js
@@ -1,7 +1,9 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { IconClose } from './icons'
 import updateQueryString from '../util/update-query-string'
 import debounce from '../util/debounce'
+
+import { README_FILENAME, THUMB_FILENAME } from '../constants';
 
 import './searchbar.scss'
 
@@ -124,22 +126,51 @@ class SearchBar extends React.Component {
 
   handleThumbnailChange = () => {
     const checked = this.refs.thumbnail.checked
-    let query
+    let query;
+    const filenames = this.props.query.filenames || [];
     if (checked) {
       query = {
         ...this.props.query,
-        filenames: ['thumbnail.png']
+        filenames: [
+          ...filenames,
+          THUMB_FILENAME
+        ]
       }
     } else {
+      const filenames = this.props.query.filenames || [];
       query = {
         ...this.props.query,
-        filenames: []
+        filenames: filenames.filter(filename => filename !== THUMB_FILENAME)
       }
     }
     this.props.setQuery(query)
 
     // update the query string in the url
     updateQueryString('thumb', checked)
+  };
+
+  // Modeled after handleThumbnailChange
+  handleReadmeChange = () => {
+    const hasReadme = this.refs.readme.checked;
+    const filenames = this.props.query.filenames || [];
+
+    let query;
+    if (hasReadme) {
+      query = {
+        ...this.props.query,
+        filenames: [
+          ...filenames,
+          README_FILENAME
+        ]
+      }
+    } else {
+      query = {
+        ...this.props.query,
+        filenames: filenames.filter(filename => filename !== README_FILENAME)
+      }
+    }
+    this.props.setQuery(query)
+    updateQueryString('hasReadme', hasReadme)
   };
 
   handleUserChange = () => {
@@ -452,7 +483,7 @@ class SearchBar extends React.Component {
           <option defaultValue="v2">v2</option>
         </select>
 
-        <div>
+        <div className='thumbnail-input-group'>
           <input
             ref="thumbnail"
             id="thumbnail-checkbox"
@@ -460,11 +491,25 @@ class SearchBar extends React.Component {
             type="checkbox"
             checked={
               this.props.query.filenames &&
-              this.props.query.filenames.includes('thumbnail.png')
+              this.props.query.filenames.includes(THUMB_FILENAME)
             }
             onChange={this.handleThumbnailChange}
           />
           <label htmlFor="thumbnail-checkbox">with thumbnail image</label>
+        </div>
+        <div className='readme-input-group'>
+          <input
+            ref="readme"
+            id="readme-checkbox"
+            className="readme-checkbox"
+            type="checkbox"
+            checked={
+              this.props.query.filenames &&
+              this.props.query.filenames.includes(README_FILENAME)
+            }
+            onChange={this.handleReadmeChange}
+          />
+          <label htmlFor="readme-checkbox">has README.md</label>
         </div>
 
         {apiDivs.length > 0 && <div id="selected-apis">{apiDivs}</div>}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,5 @@
 export const graphSearchIPAddress = '35.203.147.195'
+
+// Constants used for sending filename based queries to elasticsearch. Case sensitive.
+export const README_FILENAME = 'README.md';
+export const THUMB_FILENAME = 'thumbnail.png';


### PR DESCRIPTION
## Overview

- Addresses part 1 of #10 
- Adds `hasReadme` as a boolean URL parameter
- Uses the same API as the existing `thumb` filtering functionality
- Adjusted the existing `thumb` logic so that filename based queries can be `AND'ed` together (otherwise, each checkbox would clobber the other)
- Factors out shared constants involving modifying filename based queries, and stores them in the shared `constants` file.

## Notes

- For longevity, we may want to hoist some of this data fetching logic out of the view component, and into something like a data fetcher component. Additionally, some of the result filtering logic could be moved into `reselect` if performance became an issue.
- I developed this branch using the commits in #90, but dropped them upon opening this PR to avoid cluttering the diff. It was very convenient to be able to run the app without spinning up the whole docker stack.

## dev setup for reviewers to test

I (@micahstubbs) will document a minimal set of commands needed to bring up a dev environment for reviewers to test this PR locally.

```bash
# run mongoDb
mongod --config /usr/local/etc/mongod.conf

# open new terminal window
# run redis
redis-server

# open new terminal window
cd ../blockbuilder
yarn
yarn build
node server.js

# open new terminal window

```

sources:
https://github.com/enjalot/blockbuilder/wiki/Development#development
https://github.com/enjalot/blockbuilder-search